### PR TITLE
Chapter 08 | Bugfix, Route addition

### DIFF
--- a/ch08/lib/handlers.js
+++ b/ch08/lib/handlers.js
@@ -31,8 +31,11 @@ exports.vacationPhotoContestProcess = (req, res, fields, files) => {
   console.log('files: ', files)
   res.redirect(303, '/contest/vacation-photo-thank-you')
 }
-exports.vacationPhotoContestProcess = (req, res, fields, files) => {
+exports.vacationPhotoContestProcessError = (req, res, fields, files) => {
   res.redirect(303, '/contest/vacation-photo-error')
+}
+exports.vacationPhotoContestProcessThankYou = (req, res) => {
+  res.render('contest/vacation-photo-thank-you')
 }
 exports.api.vacationPhotoContest = (req, res, fields, files) => {
   console.log('field data: ', fields)

--- a/ch08/meadowlark.js
+++ b/ch08/meadowlark.js
@@ -53,6 +53,7 @@ app.post('/contest/vacation-photo/:year/:month', (req, res) => {
     handlers.vacationPhotoContestProcess(req, res, fields, files)
   })
 })
+app.get('/contest/vacation-photo-thank-you', handlers.vacationPhotoContestProcessThankYou)
 app.post('/api/vacation-photo-contest/:year/:month', (req, res) => {
   const form = new multiparty.Form()
   form.parse(req, (err, fields, files) => {


### PR DESCRIPTION
## Description
The var `vacationPhotoContestProcess` is in the `handlers.js` file twice. 

If a user tries the old-school form submission after submitting a form they are taken to the '/contest/vacation-photo-thank-you' but will see a 500 error.

## Solution
For the `vacationPhotoContestProcess` var t turned out that the second instance needed to be `vacationPhotoContestProcessError`.

Also there was no route for '/contest/vacation-photo-thank-you' in `meadolark.js`. With a route & handler the user will now see the thank copy after submitting an old-school form.

Notes:
Really enjoying the book. :)