### PR TITLE
Clarified & demonstrated redirect mechanism.

### DIFF
--- a/ch18-19/lib/handlers.js
+++ b/ch18-19/lib/handlers.js
@@ -2,7 +2,7 @@ const db = require('../db')
 
 exports.api = {}
 
-exports.home = (req, res) => res.render('home')
+exports.home = (req, res) => res.render('home', { username: req.user && req.user.name })
 
 // **** these handlers are for browser-submitted forms
 exports.newsletterSignup = (req, res) => {

--- a/ch18-19/meadowlark.js
+++ b/ch18-19/meadowlark.js
@@ -131,6 +131,7 @@ const customerOnly = (req, res, next) => {
   console.log('user: ', req.user)
   if(req.user && req.user.role === 'customer') return next()
   // we want customer-only pages to know they need to logon
+  req.session.authRedirect = req.originalUrl
   res.redirect(303, '/unauthorized')
 }
 const employeeOnly = (req, res, next) => {
@@ -138,6 +139,7 @@ const employeeOnly = (req, res, next) => {
   if(req.user && req.user.role === 'employee') return next()
   // we want employee-only authorization failures to be "hidden", to
   // prevent potential hackers from even knowing that such a page exists
+  req.session.authRedirect = req.originalUrl
   next('route')
 }
 

--- a/ch18-19/views/account.handlebars
+++ b/ch18-19/views/account.handlebars
@@ -1,1 +1,1 @@
-Hello, {{username}}!
+<p>Hello, {{username}}!</p>

--- a/ch18-19/views/home.handlebars
+++ b/ch18-19/views/home.handlebars
@@ -4,10 +4,15 @@
 <p>Check out our <a href="/vacations">vacation packages!</a>!</p>
 <p>Also, please enter our <a href="/contest/vacation-photo-ajax">Vacation Photo Contest</a>!</p>
 
-<ul>
-  <li><a href="/auth/facebook">Login with Facebook</a></li>
-  <li><a href="/auth/google">Login with Google</a></li>
-</ul>
+{{#if username}}
+  <p>Welcome, {{username}}!</p>
+  <p><a href="/logout">Sign Out</a></p>
+{{else}}
+  <ul>
+    <li><a href="/auth/facebook">Login with Facebook</a></li>
+    <li><a href="/auth/google">Login with Google</a></li>
+  </ul>
+{{/if}}
 
 {{> weather}}
 

--- a/ch18-19/views/unauthorized.handlebars
+++ b/ch18-19/views/unauthorized.handlebars
@@ -1,1 +1,5 @@
-Sorry, charlie.
+<p>Sorry, charlie.</p>
+<ul>
+    <li><a href="/auth/facebook">Login with Facebook</a></li>
+    <li><a href="/auth/google">Login with Google</a></li>
+</ul>


### PR DESCRIPTION
Added additional clarifying comments & finished hooking up redirect system.  You can now visit an authenticated path (like `/account/order-history`) without being logged in; you will get an access denied message, but if you then log in, you will be taken to your original destination, instead of the default auth'd page.